### PR TITLE
Failed Tasks: Display red text, suppress output on severity_level

### DIFF
--- a/nornir_rich/plugins/functions/rich_result.py
+++ b/nornir_rich/plugins/functions/rich_result.py
@@ -60,7 +60,7 @@ class RichResults(object):
         finally:
             LOCK.release()
 
-    def _print_result(  # pylama:ignore=C:select=C901
+    def _print_result(
         self,
         result: Result,
         vars: List[str] = None,
@@ -238,7 +238,7 @@ class RichResults(object):
 
     def _get_summary_count(
         self, count: int, style: str
-    ) -> Text:  # pylama:ignore=C:select=C901
+    ) -> Text:
         text = str(count) if count else "-"
         style = style if count else "no_style"
         return Text(text, style=style)


### PR DESCRIPTION
New:
- Print faild tasks with red text color

Fixed:
- functionality to suppress the output depending on severity_level parameter.

![Screenshot 2021-09-25 073321](https://user-images.githubusercontent.com/8406301/134759815-c8eca277-c52f-4556-a9c5-66e109152556.jpg)

I've seen, that the linting tests will be failing independently of this modifications. pylama, mypy, .... pytest will be okay.